### PR TITLE
Update ModernUOL.lua

### DIFF
--- a/ModernUOL.lua
+++ b/ModernUOL.lua
@@ -333,7 +333,13 @@ function ModernUOL:Attack(object)
     elseif self.ActiveOrb == _G.PaidScript.MED then
         return _G.MED.ToAttack(object)
     elseif self.ActiveOrb == _G.PaidScript.AUTO_CARRY then
-        return _G.AUTO_CARRY:Attack()
+        return _G.AUTO_CARRY:Attack(object)
+    end
+end
+
+function ModernUOL:BlockLastHit(bool)
+    if self.ActiveOrb == _G.PaidScript.AUTO_CARRY then
+        return _G.AUTO_CARRY:BlockLastHit(bool)
     end
 end
 


### PR DESCRIPTION
Game uses 2d with 3d rendering, like if you are higher elevation than your enemy it will react like enemy is closer to you than usual. If you are lower then enemy is farther than usual. That's why sometimes static boundingradius calcs are not accurated
I developed dynamic boundingradius calcs in new orb and solved this problem